### PR TITLE
Removing duplicate ->getSettings call

### DIFF
--- a/src/Crossjoin/Browscap/Parser/IniLt55.php
+++ b/src/Crossjoin/Browscap/Parser/IniLt55.php
@@ -133,7 +133,7 @@ extends AbstractParser
                         $settings = $this->getSettings($pattern);
                         if (count($settings) > 0) {
                             $formatter = Browscap::getFormatter();
-                            $formatter->setData($this->getSettings($pattern));
+                            $formatter->setData($settings);
                             break 2;
                         }
                     }


### PR DESCRIPTION
Noticed this was being called twice in the case of a final match.
Doesn’t affect performance much since it’s only called 1 extra time per
lookup (just on the final match).