### PR TITLE
Update composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,14 +32,14 @@
         "source": "https://github.com/crossjoin/Browscap"
     },
     "require": {
-        "php": "~7.0",
-        "guzzlehttp/guzzle": "~6.0.2",
+        "php": "^7.0",
+        "guzzlehttp/guzzle": "^6.0.2",
         "symfony/console": "^2.8|^3.0"
     },
     "require-dev": {
         "ext-pdo_sqlite": "*",
         "ext-sqlite3" : "*",
-        "phpunit/phpunit" : "~5.3.0"
+        "phpunit/phpunit" : "^5.3.0"
     },
     "suggest": {
         "ext-pdo_sqlite": "Either the 'pdo_sqlite' or the 'sqlite3' extension is required.",


### PR DESCRIPTION
I'm not sure why there are strict qualifications on the minor version updates, guzzle is at 5.2 at the moment and it seems silly to prevent updates because of a minor version change.  Relax from the tilde range selector to the caret range selector to allow minor upgrades.