### PR TITLE
replace line endings for windows generated files

### DIFF
--- a/src/Source/Ini/DataSetsFromContentTrait.php
+++ b/src/Source/Ini/DataSetsFromContentTrait.php
@@ -73,6 +73,11 @@ trait DataSetsFromContentTrait
             throw new ParserRuntimeException('The data could not be parsed (no pattern found).', 1459589758);
         }
 
+        if (strpos($data, "\r\n") !== false) {
+            // if the source file was created under windows, replace the line endings
+            $data = str_replace("\r\n", "\n", $data);
+        }
+
         // Prepare the data from the data set
         list($pattern, $properties) = explode("\n", $data, 2);
         $pattern = substr($pattern, 1, -1);


### PR DESCRIPTION
If the browscap.ini file was generated on a Windows system, each getbrowser call will fail with an exception
```php
Crossjoin\Browscap\Exception\ParserRuntimeException: Parent 'DefaultProperties' not found.
```
This PR wants to solve this.

NOTE: I only tested this with version 2.x, because actually I dont have a system with PHP 7.